### PR TITLE
Enable multiple session stores

### DIFF
--- a/gormstore.go
+++ b/gormstore.go
@@ -73,6 +73,9 @@ type gormSession struct {
 	tableName string `sql:"-"` // just for convenience instead of db.Table(...)
 }
 
+// Define a type for context keys so that they can't clash with anything else stored in context
+type contextKey string
+
 func (gs *gormSession) TableName() string {
 	return gs.tableName
 }
@@ -130,7 +133,7 @@ func (st *Store) New(r *http.Request, name string) (*sessions.Session, error) {
 			return session, nil
 		}
 
-		context.Set(r, name, s)
+		context.Set(r, contextKey(name), s)
 	}
 
 	return session, nil
@@ -138,7 +141,7 @@ func (st *Store) New(r *http.Request, name string) (*sessions.Session, error) {
 
 // Save session and set cookie header
 func (st *Store) Save(r *http.Request, w http.ResponseWriter, session *sessions.Session) error {
-	s, _ := context.Get(r, session.Name()).(*gormSession)
+	s, _ := context.Get(r, contextKey(session.Name())).(*gormSession)
 
 	// delete if max age is < 0
 	if session.Options.MaxAge < 0 {
@@ -174,7 +177,7 @@ func (st *Store) Save(r *http.Request, w http.ResponseWriter, session *sessions.
 		if err := st.db.Create(s).Error; err != nil {
 			return err
 		}
-		context.Set(r, session.Name(), s)
+		context.Set(r, contextKey(session.Name()), s)
 	} else {
 		s.Data = data
 		s.UpdatedAt = now

--- a/gormstore.go
+++ b/gormstore.go
@@ -77,13 +77,6 @@ func (gs *gormSession) TableName() string {
 	return gs.tableName
 }
 
-type contextKey int
-
-const (
-	// request context key, stores a *gormSession
-	contextGormstore contextKey = iota
-)
-
 // New creates a new gormstore session
 func New(db *gorm.DB, keyPairs ...[]byte) *Store {
 	return NewOptions(db, Options{}, keyPairs...)
@@ -137,7 +130,7 @@ func (st *Store) New(r *http.Request, name string) (*sessions.Session, error) {
 			return session, nil
 		}
 
-		context.Set(r, contextGormstore, s)
+		context.Set(r, name, s)
 	}
 
 	return session, nil
@@ -145,7 +138,7 @@ func (st *Store) New(r *http.Request, name string) (*sessions.Session, error) {
 
 // Save session and set cookie header
 func (st *Store) Save(r *http.Request, w http.ResponseWriter, session *sessions.Session) error {
-	s, _ := context.Get(r, contextGormstore).(*gormSession)
+	s, _ := context.Get(r, session.Name()).(*gormSession)
 
 	// delete if max age is < 0
 	if session.Options.MaxAge < 0 {
@@ -181,7 +174,7 @@ func (st *Store) Save(r *http.Request, w http.ResponseWriter, session *sessions.
 		if err := st.db.Create(s).Error; err != nil {
 			return err
 		}
-		context.Set(r, contextGormstore, s)
+		context.Set(r, session.Name(), s)
 	} else {
 		s.Data = data
 		s.UpdatedAt = now

--- a/gormstore_test.go
+++ b/gormstore_test.go
@@ -40,7 +40,7 @@ func connectDbURI(uri string) (*gorm.DB, error) {
 	for i := 0; i < 50; i++ {
 		g, err := gorm.Open(driver, dsn)
 		if err == nil {
-			return &g, nil
+			return g, nil
 		}
 		time.Sleep(500 * time.Millisecond)
 	}


### PR DESCRIPTION
I'm using gormstore to handle both my own session cookies and those used by [goth](http://github.com/markbates/goth) for OAuth logins. This ran into trouble because my two instances of the session store need to store information in the context, but they were using the same key. In this PR I'm using "session name" (actually cookie name) as the key in context. 

(There's also a little fix to the texts, which gets a ton of them working.) 